### PR TITLE
Fix macOS capture

### DIFF
--- a/obwsc/commands/pause_record.py
+++ b/obwsc/commands/pause_record.py
@@ -1,8 +1,6 @@
 from obwsc.commands.event_based_command import EventBasedCommand
 
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class PauseRecord(EventBasedCommand):
@@ -28,10 +26,9 @@ class PauseRecord(EventBasedCommand):
             raise RuntimeError('Recording is not active')
 
         if status.output_paused:
-            log.debug('Recording is already paused')
+            Log.debug('Recording is already paused')
             self.done.set()
             return
 
         self.ws.pause_record()
         self.done.wait()
-

--- a/obwsc/commands/resume_record.py
+++ b/obwsc/commands/resume_record.py
@@ -1,6 +1,7 @@
 from obwsc.commands.event_based_command import EventBasedCommand
+from obsws_python.error import OBSSDKRequestError
 
-import logging
+import sys
 
 from obwsc.log import Log
 
@@ -22,6 +23,21 @@ class ResumeRecord(EventBasedCommand):
         if event.output_state == 'OBS_WEBSOCKET_OUTPUT_RESUMED':
             self.done.set()
 
+    def _restart_macos_inputs(self):
+        # On macOS the "screen capture" inputs get "broken" after locking the screen, but luckily OBS provides a button
+        # for restarting the capture.
+        # In this function we are iterating over all inputs, where this button is present and ask OBS to press it.
+        if sys.platform != 'darwin':
+            Log.debug(f'Skipping screen capture restarts: not on macOS: {sys.platform}')
+            return
+
+        resp = self.ws.get_input_list('screen_capture')
+        for capture in resp.inputs:
+            try:
+                self.ws.press_input_properties_button(capture['inputName'], "reactivate_capture")
+            except OBSSDKRequestError:
+                Log.debug(f'Screen capture reactivation failed for "{capture["inputName"]}"')
+
     def execute(self):
         status = self.ws.get_record_status()
         if not status.output_active:
@@ -30,7 +46,9 @@ class ResumeRecord(EventBasedCommand):
         if not status.output_paused:
             Log.debug('Recording is already running')
             self.done.set()
-            return
+        else:
+            self.ws.resume_record()
 
-        self.ws.resume_record()
         self.done.wait()
+
+        self._restart_macos_inputs()

--- a/obwsc/commands/resume_record.py
+++ b/obwsc/commands/resume_record.py
@@ -2,7 +2,7 @@ from obwsc.commands.event_based_command import EventBasedCommand
 
 import logging
 
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class ResumeRecord(EventBasedCommand):
@@ -28,7 +28,7 @@ class ResumeRecord(EventBasedCommand):
             raise RuntimeError('Recording is not active')
 
         if not status.output_paused:
-            log.debug('Recording is already running')
+            Log.debug('Recording is already running')
             self.done.set()
             return
 

--- a/obwsc/commands/set_current_profile.py
+++ b/obwsc/commands/set_current_profile.py
@@ -2,9 +2,7 @@ import argparse
 
 from obwsc.commands.event_based_command import EventBasedCommand
 
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class SetCurrentProfile(EventBasedCommand):
@@ -39,7 +37,7 @@ class SetCurrentProfile(EventBasedCommand):
             raise RuntimeError(f'Profile "{self.target_profile}" does not exist')
 
         if profiles.current_profile_name == self.target_profile:
-            log.debug('Profile already active')
+            Log.debug('Profile already active')
             return
 
         status = self.ws.get_record_status()
@@ -48,4 +46,3 @@ class SetCurrentProfile(EventBasedCommand):
 
         self.ws.set_current_profile(self.target_profile)
         self.done.wait()
-

--- a/obwsc/commands/set_current_scene_collection.py
+++ b/obwsc/commands/set_current_scene_collection.py
@@ -2,9 +2,7 @@ import argparse
 
 from obwsc.commands.event_based_command import EventBasedCommand
 
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class SetCurrentSceneCollection(EventBasedCommand):
@@ -39,7 +37,7 @@ class SetCurrentSceneCollection(EventBasedCommand):
             raise RuntimeError(f'Scene collection "{self.target_collection}" does not exist')
 
         if scenes.current_scene_collection_name == self.target_collection:
-            log.debug('Scene collection already active')
+            Log.debug('Scene collection already active')
             return
 
         self.ws.set_current_scene_collection(self.target_collection)

--- a/obwsc/commands/start_record.py
+++ b/obwsc/commands/start_record.py
@@ -1,8 +1,6 @@
 from obwsc.commands.event_based_command import EventBasedCommand
 
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class StartRecord(EventBasedCommand):
@@ -25,10 +23,9 @@ class StartRecord(EventBasedCommand):
     def execute(self):
         status = self.ws.get_record_status()
         if status.output_active:
-            log.debug('Recording is already running')
+            Log.debug('Recording is already running')
             self.done.set()
             return
 
         self.ws.start_record()
         self.done.wait()
-

--- a/obwsc/commands/stop_record.py
+++ b/obwsc/commands/stop_record.py
@@ -1,8 +1,6 @@
 from obwsc.commands.event_based_command import EventBasedCommand
 
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class StopRecord(EventBasedCommand):
@@ -25,10 +23,9 @@ class StopRecord(EventBasedCommand):
     def execute(self):
         status = self.ws.get_record_status()
         if not status.output_active:
-            log.debug('Recording is already stopped')
+            Log.debug('Recording is already stopped')
             self.done.set()
             return
 
         self.ws.stop_record()
         self.done.wait()
-

--- a/obwsc/commands/switch_profile_and_scene_collection.py
+++ b/obwsc/commands/switch_profile_and_scene_collection.py
@@ -6,10 +6,7 @@ from obwsc.commands.stop_record import StopRecord
 from obwsc.commands.start_record import StartRecord
 from obwsc.commands.set_current_profile import SetCurrentProfile
 from obwsc.commands.set_current_scene_collection import SetCurrentSceneCollection
-
-import logging
-
-log = logging.getLogger('obwsc')
+from obwsc.log import Log
 
 
 class SwitchProfileAndSceneCollection(EventBasedCommand):
@@ -50,7 +47,7 @@ class SwitchProfileAndSceneCollection(EventBasedCommand):
         change_scene = scenes.current_scene_collection_name != self.target_collection
 
         if not change_profile and not change_scene:
-            log.debug('Profile and scene collection already active')
+            Log.debug('Profile and scene collection already active')
             return
 
         if change_profile:

--- a/obwsc/log.py
+++ b/obwsc/log.py
@@ -1,9 +1,29 @@
 from argparse import ArgumentParser
 
 import logging
+from typing import Optional
 
 
 class Log:
+    INSTANCE = None  # type: Optional[Log]
+    LOGGER_NAME = 'obwsc'
+    FORMAT_STRING = '[%(asctime)s][%(levelname)s][%(name)s] %(message)s'
+
+    def __init__(self, level: int):
+        self.formatter = logging.Formatter(Log.FORMAT_STRING)
+        self.level = level
+
+        self.logger = logging.getLogger(Log.LOGGER_NAME)
+        self.logger.setLevel(level)
+        self.logger.propagate = False
+
+        self._add_handler(self.logger, logging.StreamHandler())
+
+    def _add_handler(self, logger, handler):
+        handler.setLevel(self.level)
+        handler.setFormatter(self.formatter)
+        logger.addHandler(handler)
+
     @staticmethod
     def add_args(parser: ArgumentParser):
         verbosity = parser.add_mutually_exclusive_group()
@@ -19,4 +39,37 @@ class Log:
         else:
             level = logging.ERROR
 
-        logging.basicConfig(level=level)
+        if Log.INSTANCE is None:
+            Log.INSTANCE = Log(level)
+        else:
+            raise RuntimeError('Logger already initialized')
+
+    @staticmethod
+    def debug(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.debug(*args, **kwargs)
+
+    @staticmethod
+    def info(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.info(*args, **kwargs)
+
+    @staticmethod
+    def warning(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.warning(*args, **kwargs)
+
+    @staticmethod
+    def error(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.error(*args, **kwargs)
+
+    @staticmethod
+    def exception(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.exception(*args, **kwargs)
+
+    @staticmethod
+    def fatal(*args, **kwargs):
+        assert Log.INSTANCE is not None
+        Log.INSTANCE.logger.fatal(*args, **kwargs)

--- a/obwsc/options.py
+++ b/obwsc/options.py
@@ -16,7 +16,7 @@ class Options:
 
         # Handle the case where we are compiled into a standalone package
         if sys.platform == 'darwin' and 'Contents/MacOS' in result:
-            # We are inside an macOS bundle
+            # We are inside af a macOS bundle
             result = os.path.abspath(os.path.join(result, '..', '..', '..'))
         else:
             result = os.getcwd()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-obsws-python~=1.4.1
+obsws-python~=1.7.0
 toml~=0.10.2


### PR DESCRIPTION
Restart macOS capture upon resumption

This way the new (non-deprecated) capture will be automatically fixed
in case the screen was previously locked.